### PR TITLE
Fix broken SOS Capabilities link in legend entries Issue #18

### DIFF
--- a/src/common/timeseries/diagram/legend-entry/legend-entry.component.html
+++ b/src/common/timeseries/diagram/legend-entry/legend-entry.component.html
@@ -65,6 +65,15 @@
         </n52-custom-dataset-permalink-download>
       </div>
 
+      <div class="additionalLegendEntry"(click)="$event.stopPropagation();" *ngIf="getFixedCapabilitiesUrl()">
+        <a [href]="getFixedCapabilitiesUrl()"
+            target="_blank"
+            rel="noopener noreferrer">
+            <span class="fa fa-external-link-alt"></span>
+            <span>SOS Capabilities</span>
+        </a>
+      </div>
+
       <!-- temporarly disabled -->
       <!-- <div class="firstLastEntry additionalLegendEntry" *ngIf="hasData" (click)="$event.stopPropagation();">
         <span class="fa fa-download"></span>

--- a/src/common/timeseries/diagram/legend-entry/legend-entry.component.ts
+++ b/src/common/timeseries/diagram/legend-entry/legend-entry.component.ts
@@ -19,4 +19,12 @@ export class LegendEntryComponent extends TimeseriesEntryComponent {
     }
   }
 
+  public getFixedCapabilitiesUrl(): string {
+  if (!this.dataset?.url) {
+    return '';
+  }
+  const baseUrl = this.dataset.url.split('?')[0];
+  return `${baseUrl}?service=SOS&request=GetCapabilities`;
+}
+
 }


### PR DESCRIPTION
Fixes the broken **SOS Capabilities** link in the diagram legend.
Generates a correct `GetCapabilities` URL by stripping client specific paths from the SOS endpoint.
Adds a safe, non intrusive link in the legend details that opens the capabilities document in a new tab.
